### PR TITLE
fix: colors for tmux and vim in alacritty for macos and linux

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -27,6 +27,9 @@ style = "Regular"
 args = ["bash", "-c", "source ~/.profile && tmux -2 new-session -A -s main"]
 program = "/usr/bin/env"
 
+[env]
+TERM = "xterm-256color"
+
 [window.padding]
 x = 3
 y = 3

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -12,7 +12,7 @@ set -g status-right '%d/%m %H:%M '
 
 setw -g window-status-current-style 'fg=#a89984'
 
-set-option -g default-terminal 'tmux-256color'
+set-option -g default-terminal 'xterm-256color'
 set-option -ga terminal-overrides ",xterm-256color:Tc"
 
 

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -10,7 +10,6 @@ export SCRIPTS="${DOTFILES}/scripts"
 export SB="${REPOS}/${GH_USER}/second-brain"
 export HISTSIZE=5000
 export HISTFILESIZE=10000
-export TERM="xterm-256color"
 
 export PYENV_ROOT="$TOOLS/pyenv"
 export TFENV_ROOT="$TOOLS/tfenv"

--- a/home/.profile
+++ b/home/.profile
@@ -1,5 +1,5 @@
 if [[ -f /etc/profile ]]; then
-  PATH=""
+  PATH="/usr/local/bin:/usr/bin:/bin"
   source /etc/profile
 fi
 


### PR DESCRIPTION
<https://gist.github.com/andersevenrud/015e61af2fd264371032763d4ed965b6>